### PR TITLE
Fix YouTube modal video sizing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -148,6 +148,13 @@ main {
   background-color: #000;
 }
 
+/* Ensure the embedded player fills the modal */
+.modal-content iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 .close-button {
   position: absolute;
   top: -30px;


### PR DESCRIPTION
## Summary
- ensure the embedded player fills the modal by adding iframe styling

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68703b7efe6c8333973f595c81dff6ef